### PR TITLE
docs: add missing instructions in contributing guide

### DIFF
--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -7,6 +7,8 @@ Developing aya requires [Node.js](https://nodejs.org) and Android SDK tools.
 After cloning the repository, run the following commands:
 
 ```bash
+# fetch submodules.
+git submodule update --init --recursive
 # Install npm dependencies.
 npm install
 # Download adb tools.

--- a/docs/zh/guide/contributing.md
+++ b/docs/zh/guide/contributing.md
@@ -7,6 +7,8 @@
 在克隆仓库后，运行以下命令：
 
 ```bash
+# 拉取子模块。
+git submodule update --init --recursive
 # 安装 npm 依赖。
 npm install
 # 下载 adb 工具。


### PR DESCRIPTION
Add step of fetching submodule to avoid pitfall for latter contributors.